### PR TITLE
Added in combinator: validate existence in Set

### DIFF
--- a/core/src/main/scala/com/wix/accord/combinators/CollectionCombinators.scala
+++ b/core/src/main/scala/com/wix/accord/combinators/CollectionCombinators.scala
@@ -16,10 +16,9 @@
 
 package com.wix.accord.combinators
 
-import com.wix.accord.{Validator, NullSafeValidator}
+import com.wix.accord.{BaseValidator, Validator, NullSafeValidator}
 import com.wix.accord.ViolationBuilder._
 
-import scala.collection.TraversableLike
 
 /** Combinators that operate on collections and collection-like structures. */
 trait CollectionCombinators {
@@ -75,4 +74,7 @@ trait CollectionCombinators {
         )
       }
   }
+  /** A validator that succeeds only if the object exists in the target collection. */
+  case class In[T](  set: Set[T], prefix: String )
+    extends BaseValidator[T]( item=>set.contains(item ), v => v -> s"$prefix $v, expected one of: ${set.mkString(",")}" )
 }

--- a/core/src/main/scala/com/wix/accord/dsl/CollectionOps.scala
+++ b/core/src/main/scala/com/wix/accord/dsl/CollectionOps.scala
@@ -17,12 +17,13 @@
 package com.wix.accord.dsl
 
 import com.wix.accord.Validator
-import com.wix.accord.combinators.{Distinct, Empty, HasEmpty, NotEmpty}
+import com.wix.accord.combinators.{Distinct, Empty, HasEmpty, NotEmpty,In}
 import scala.collection.GenTraversableOnce
 import scala.language.implicitConversions
 
 /** Provides a DSL for collection-like objects. Works in conjunction with [[com.wix.accord.dsl.DslContext]]. */
 trait CollectionOps {
+  protected def prefix: String = "got"
   /** Specifies a validator that succeeds on empty instances; the object under validation must implement
     * `def isEmpty: Boolean` (see [[com.wix.accord.combinators.HasEmpty]]).
     */
@@ -63,4 +64,8 @@ trait CollectionOps {
     * `c.students has size > 0`.
     */
   val size = new OrderingOps { override def snippet = "has size" }
+
+  def in[T]( set: Set[T] ): Validator[ T ]  = In( set, prefix )
+
+  def in[ T ]( items: T* ): Validator[ T ]  = In( items.toSet, prefix )
 }

--- a/core/src/test/scala/com/wix/accord/tests/combinators/CollectionCombinatorTests.scala
+++ b/core/src/test/scala/com/wix/accord/tests/combinators/CollectionCombinatorTests.scala
@@ -16,7 +16,7 @@
 
 package com.wix.accord.tests.combinators
 
-import com.wix.accord.combinators.{Empty, NotEmpty, Distinct}
+import com.wix.accord.combinators.{Empty, NotEmpty, Distinct,In}
 
 class CollectionCombinatorTests extends CombinatorTestSpec {
 
@@ -91,4 +91,14 @@ class CollectionCombinatorTests extends CombinatorTestSpec {
       validator( left ) should failWith( "is not a distinct set; duplicates: [3, 4]" )
     }
   }
+  "In combinator" should {
+    val validator = new In(Set(1,5,9),"got")
+    "successfully validate a number in range" in {
+      validator(1)  should be( aSuccess )
+    }
+    "render a correct rule violation" in {
+      validator(2)  should failWith( "got 2, expected one of: 1,5,9" )
+    }
+  }
+
 }

--- a/core/src/test/scala/com/wix/accord/tests/dsl/CollectionOpsTests.scala
+++ b/core/src/test/scala/com/wix/accord/tests/dsl/CollectionOpsTests.scala
@@ -31,7 +31,8 @@ object CollectionOpsTests {
   val emptyValidator = seq is empty
   val notEmptyValidator = seq is notEmpty
   val distinctValidator = seq is distinct
-  
+  val inValidator= 1 is in (1,3,5)
+
   class Sized( _size: Int ) {
     private var _visited = false
     def size: Int = { _visited = true; _size }
@@ -49,7 +50,7 @@ object CollectionOpsTests {
 
 class CollectionOpsTests extends WordSpec with Matchers with ResultMatchers with Inside {
   import CollectionOpsTests._
-  import combinators.{Empty, NotEmpty, Distinct}
+  import combinators.{Empty, NotEmpty, Distinct,In}
 
 
   "Calling \"has size\"" should {
@@ -135,6 +136,11 @@ class CollectionOpsTests extends WordSpec with Matchers with ResultMatchers with
         }
 
       result should failWith( failing map matcherFor :_* )
+    }
+  }
+  "Operator \"in\" over a set" should{
+    "return an In combinator" in {
+      inValidator shouldEqual In(Set(1,3,5),"got")
     }
   }
 }


### PR DESCRIPTION
_Usage_:
```scala
validator[ CreditCard] { c =>
  c.cardNumber is in (8,14,16)
}
```
Raised in Issue #32 
