### PR TITLE
Adding toString implementation for RuleViolation and GroupViolation

### DIFF
--- a/api/src/main/scala/com/wix/accord/Result.scala
+++ b/api/src/main/scala/com/wix/accord/Result.scala
@@ -54,6 +54,8 @@ case class RuleViolation(value: Any,
 
   def applyDescription( description: Description ) =
     this.copy( description = Descriptions.combine( this.description, description ) )
+
+  override def toString: String = s"${Descriptions.render(description)} $constraint"
 }
 
 /** Describes the violation of a group of constraints. For example, the `Or` combinator found in the built-in
@@ -73,6 +75,8 @@ case class GroupViolation(value: Any,
 
   def applyDescription( description: Description ) =
     this.copy( description = Descriptions.combine( this.description, description ) )
+
+  override def toString: String = s"${Descriptions.render(description)} $constraint: ${children.toString}"
 }
 
 /** A base trait for validation results.

--- a/api/src/test/scala/com/wix/accord/ViolationSpec.scala
+++ b/api/src/test/scala/com/wix/accord/ViolationSpec.scala
@@ -1,0 +1,27 @@
+package com.wix.accord
+
+import com.wix.accord.Descriptions.Generic
+import org.scalatest.{FlatSpec, Matchers}
+
+/**
+  * Created by grenville on 9/6/16.
+  */
+class ViolationSpec extends FlatSpec with Matchers {
+
+  val subSampleRule = RuleViolation("value", "is null", Generic("subSampleRule"))
+  val subSampleGroup = GroupViolation("subgroup", "is not valid",
+    children = Set(subSampleRule), Generic("request"))
+  val sampleRule1 = RuleViolation("value", "is null", Generic("sampleRule1"))
+  val sampleRule2 = RuleViolation("value", "is null", Generic("sampleRule2"))
+  val sampleGroup = GroupViolation("group", "is not valid",
+    children = Set(sampleRule1, sampleRule2, subSampleGroup), Generic("request"))
+
+  "Violation" should "produce a string representation for a RuleViolation" in {
+    sampleRule1.toString shouldEqual "sampleRule1 is null"
+  }
+
+  it should "produce a string representation for a GroupViolation" in {
+    sampleGroup.toString shouldEqual "request is not valid: Set(sampleRule1 is null, sampleRule2 is null, " +
+      "subgroup is not valid: Set(subSampleRule is null))"
+  }
+}


### PR DESCRIPTION
This is a shot at addressing issue #78, adding a nice `toString` implementation for `Violation`. I'm a little concerned about the recursive aspect though, since a GroupViolation can contain another GroupViolation. Would you prefer that was handled with an @tailrec annotated method or ScalaZ's `Trampoline`?
