### PR TITLE
Restores build to working condition and other administrativa

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 
 scala:
   - "2.11.12"
-  - "2.12.0"
+  - "2.12.6"
   - "2.13.0-M2"
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 
 scala:
-  - "2.11.1"
+  - "2.11.12"
   - "2.12.0"
   - "2.13.0-M2"
 
@@ -20,13 +20,6 @@ jdk:
   - oraclejdk8
   - oraclejdk9
   - oraclejdk10
-
-# Trying out new JDK 8-10 matrix, if it works this section will go away. --TG
-#matrix:
-#  include:
-#    # Add JDK 9 build, currently only available with 2.13.0
-#    - jdk: oraclejdk9
-#      scala: "2.13.0-M2"
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,7 @@ after_success:
 
 jdk:
   - oraclejdk8
-  - oraclejdk9
-  - oraclejdk10
+  - oraclejdk11
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,18 +12,21 @@ script:
   - sbt ++$TRAVIS_SCALA_VERSION jsRoot/clean jsRoot/test
 
 after_success:
-  # Snapshot publishing via Travis courtesy of Jan Machacek, thanks!
+  # Snapshot publishing via Travis (only for authoritative repo and on master branch) courtesy of Jan Machacek, thanks!
   # http://www.cakesolutions.net/teamblogs/publishing-artefacts-to-oss-sonatype-nexus-using-sbt-and-travis-ci
-  - "[[ $TRAVIS_BRANCH == \"master\" ]] && { sbt \"++$TRAVIS_SCALA_VERSION publish\"; };"
+  - "[[ \"$TRAVIS_REPO_SLUG\" == \"wix/accord\" ]] && [[ \"$TRAVIS_BRANCH\" == \"master\" ]] && { sbt \"++$TRAVIS_SCALA_VERSION publish\"; };"
 
 jdk:
   - oraclejdk8
+  - oraclejdk9
+  - oraclejdk10
 
-matrix:
-  include:
-    # Add JDK 9 build, currently only available with 2.13.0
-    - jdk: oraclejdk9
-      scala: "2.13.0-M2"
+# Trying out new JDK 8-10 matrix, if it works this section will go away. --TG
+#matrix:
+#  include:
+#    # Add JDK 9 build, currently only available with 2.13.0
+#    - jdk: oraclejdk9
+#      scala: "2.13.0-M2"
 
 env:
   global:

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright 2013-2017 Wix.com
+Copyright 2013-2019 Wix.com
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-[![Build Status](https://travis-ci.org/wix/accord.svg?branch=master)](https://travis-ci.org/wix/accord) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/wix/accord?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge) [![Maven Central](https://img.shields.io/maven-central/v/com.wix/accord-core_2.11.svg?maxAge=3600)](http://search.maven.org/#search|gav|1|g:com.wix%20AND%20a:accord*)
+[![Build Status](https://travis-ci.org/wix/accord.svg?branch=master)](https://travis-ci.org/wix/accord) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/wix/accord?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge) [![Maven Central](https://img.shields.io/maven-central/v/com.wix/accord-core_2.11.svg?maxAge=3600)](http://search.maven.org/#search|gav|1|g:com.wix%20AND%20a:accord*) [![Scala.js](https://www.scala-js.org/assets/badges/scalajs-0.6.17.svg)](https://www.scala-js.org)
 
 
 Overview

--- a/api/src/main/scala/com/wix/accord/BaseValidator.scala
+++ b/api/src/main/scala/com/wix/accord/BaseValidator.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/api/src/main/scala/com/wix/accord/Descriptions.scala
+++ b/api/src/main/scala/com/wix/accord/Descriptions.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/api/src/main/scala/com/wix/accord/Implicits.scala
+++ b/api/src/main/scala/com/wix/accord/Implicits.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/api/src/main/scala/com/wix/accord/Result.scala
+++ b/api/src/main/scala/com/wix/accord/Result.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/api/src/main/scala/com/wix/accord/Validator.scala
+++ b/api/src/main/scala/com/wix/accord/Validator.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/api/src/main/scala/com/wix/accord/ViolationBuilder.scala
+++ b/api/src/main/scala/com/wix/accord/ViolationBuilder.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/api/src/main/scala/com/wix/accord/package.scala
+++ b/api/src/main/scala/com/wix/accord/package.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/api/src/test/scala/com/wix/accord/DebugRenderingSpec.scala
+++ b/api/src/test/scala/com/wix/accord/DebugRenderingSpec.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/api/src/test/scala/com/wix/accord/DescriptionRenderingSpec.scala
+++ b/api/src/test/scala/com/wix/accord/DescriptionRenderingSpec.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/build.sbt
+++ b/build.sbt
@@ -203,7 +203,7 @@ lazy val spring3 =
       libraryDependencies ++= Seq(
         "javax.xml.bind" % "jaxb-api" % "2.3.0",
         "javax.annotation" % "javax.annotation-api" % "1.3.1",
-        "org.apache.commons" % "commons-lang3" % "3.7"
+        "org.apache.commons" % "commons-lang3" % "3.8"
       )
     ) }
     .dependsOn( apiJVM, scalatestJVM % "test->compile", coreJVM % "test->compile" )

--- a/build.sbt
+++ b/build.sbt
@@ -52,8 +52,8 @@ def limitPackageSize( allowedSizeInKB: Int ) =
 lazy val compileOptions = Seq(
   scalaVersion := "2.12.0",
   crossScalaVersions := ( Helpers.javaVersion match {
-    case v if v >= 1.8 => Seq( "2.11.1", "2.12.0", "2.13.0-M2" )
-    case _             => Seq( "2.11.1" )
+    case v if v >= 1.8 => Seq( "2.11.12", "2.12.0", "2.13.0-M2" )
+    case _             => Seq( "2.11.12" )
   } ),
   scalacOptions ++= Seq(
     "-language:reflectiveCalls",

--- a/build.sbt
+++ b/build.sbt
@@ -50,9 +50,9 @@ def limitPackageSize( allowedSizeInKB: Int ) =
   }
 
 lazy val compileOptions = Seq(
-  scalaVersion := "2.12.0",
+  scalaVersion := "2.12.6",
   crossScalaVersions := ( Helpers.javaVersion match {
-    case v if v >= 1.8 => Seq( "2.11.12", "2.12.0", "2.13.0-M2" )
+    case v if v >= 1.8 => Seq( "2.11.12", "2.12.6", "2.13.0-M2" )
     case _             => Seq( "2.11.12" )
   } ),
   scalacOptions ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -203,7 +203,7 @@ lazy val spring3 =
       libraryDependencies ++= Seq(
         "javax.xml.bind" % "jaxb-api" % "2.3.0",
         "javax.annotation" % "javax.annotation-api" % "1.3.1",
-        "org.apache.commons" % "commons-lang3" % "3.5"
+        "org.apache.commons" % "commons-lang3" % "3.7"
       )
     ) }
     .dependsOn( apiJVM, scalatestJVM % "test->compile", coreJVM % "test->compile" )

--- a/core/src/main/scala/com/wix/accord/ResultBuilders.scala
+++ b/core/src/main/scala/com/wix/accord/ResultBuilders.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/wix/accord/combinators/BooleanCombinators.scala
+++ b/core/src/main/scala/com/wix/accord/combinators/BooleanCombinators.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/wix/accord/combinators/CollectionCombinators.scala
+++ b/core/src/main/scala/com/wix/accord/combinators/CollectionCombinators.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/wix/accord/combinators/GeneralPurposeCombinators.scala
+++ b/core/src/main/scala/com/wix/accord/combinators/GeneralPurposeCombinators.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/wix/accord/combinators/OrderingCombinators.scala
+++ b/core/src/main/scala/com/wix/accord/combinators/OrderingCombinators.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/wix/accord/combinators/StringCombinators.scala
+++ b/core/src/main/scala/com/wix/accord/combinators/StringCombinators.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/wix/accord/combinators/package.scala
+++ b/core/src/main/scala/com/wix/accord/combinators/package.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/wix/accord/dsl/Aggregates.scala
+++ b/core/src/main/scala/com/wix/accord/dsl/Aggregates.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/wix/accord/dsl/BooleanOps.scala
+++ b/core/src/main/scala/com/wix/accord/dsl/BooleanOps.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/wix/accord/dsl/CollectionOps.scala
+++ b/core/src/main/scala/com/wix/accord/dsl/CollectionOps.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/wix/accord/dsl/DslContext.scala
+++ b/core/src/main/scala/com/wix/accord/dsl/DslContext.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/wix/accord/dsl/GenericOps.scala
+++ b/core/src/main/scala/com/wix/accord/dsl/GenericOps.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/wix/accord/dsl/OrderingOps.scala
+++ b/core/src/main/scala/com/wix/accord/dsl/OrderingOps.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/wix/accord/dsl/StringOps.scala
+++ b/core/src/main/scala/com/wix/accord/dsl/StringOps.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/wix/accord/dsl/package.scala
+++ b/core/src/main/scala/com/wix/accord/dsl/package.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/wix/accord/transform/ExpressionDescriber.scala
+++ b/core/src/main/scala/com/wix/accord/transform/ExpressionDescriber.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/wix/accord/transform/MacroHelper.scala
+++ b/core/src/main/scala/com/wix/accord/transform/MacroHelper.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/wix/accord/transform/MacroLogging.scala
+++ b/core/src/main/scala/com/wix/accord/transform/MacroLogging.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/wix/accord/transform/PatternHelper.scala
+++ b/core/src/main/scala/com/wix/accord/transform/PatternHelper.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/wix/accord/transform/RuleFinder.scala
+++ b/core/src/main/scala/com/wix/accord/transform/RuleFinder.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/wix/accord/transform/ValidationTransform.scala
+++ b/core/src/main/scala/com/wix/accord/transform/ValidationTransform.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/wix/accord/BaseValidatorTests.scala
+++ b/core/src/test/scala/com/wix/accord/BaseValidatorTests.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/wix/accord/tests/combinators/BooleanCombinatorTests.scala
+++ b/core/src/test/scala/com/wix/accord/tests/combinators/BooleanCombinatorTests.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/wix/accord/tests/combinators/CollectionCombinatorTests.scala
+++ b/core/src/test/scala/com/wix/accord/tests/combinators/CollectionCombinatorTests.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/wix/accord/tests/combinators/GeneralPurposeCombinatorTests.scala
+++ b/core/src/test/scala/com/wix/accord/tests/combinators/GeneralPurposeCombinatorTests.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/wix/accord/tests/combinators/OrderingCombinatorTests.scala
+++ b/core/src/test/scala/com/wix/accord/tests/combinators/OrderingCombinatorTests.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/wix/accord/tests/combinators/StringCombinatorTests.scala
+++ b/core/src/test/scala/com/wix/accord/tests/combinators/StringCombinatorTests.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/wix/accord/tests/dsl/AlternativeValidationSyntaxTests.scala
+++ b/core/src/test/scala/com/wix/accord/tests/dsl/AlternativeValidationSyntaxTests.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/wix/accord/tests/dsl/BooleanOpsTests.scala
+++ b/core/src/test/scala/com/wix/accord/tests/dsl/BooleanOpsTests.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/wix/accord/tests/dsl/CollectionOpsTests.scala
+++ b/core/src/test/scala/com/wix/accord/tests/dsl/CollectionOpsTests.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/wix/accord/tests/dsl/GenericOpsTests.scala
+++ b/core/src/test/scala/com/wix/accord/tests/dsl/GenericOpsTests.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/wix/accord/tests/dsl/OptionOpsTests.scala
+++ b/core/src/test/scala/com/wix/accord/tests/dsl/OptionOpsTests.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/wix/accord/tests/dsl/OrderingOpsTests.scala
+++ b/core/src/test/scala/com/wix/accord/tests/dsl/OrderingOpsTests.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/wix/accord/tests/dsl/StringOpsTests.scala
+++ b/core/src/test/scala/com/wix/accord/tests/dsl/StringOpsTests.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/wix/accord/tests/transform/ExpressionDescriberTests.scala
+++ b/core/src/test/scala/com/wix/accord/tests/transform/ExpressionDescriberTests.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/core/src/test/scala/com/wix/accord/tests/transform/ValidationTransformTests.scala
+++ b/core/src/test/scala/com/wix/accord/tests/transform/ValidationTransformTests.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/examples/src/main/scala/com/wix/accord/examples/Domain.scala
+++ b/examples/src/main/scala/com/wix/accord/examples/Domain.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/com/wix/accord/examples/ScalaTest.scala
+++ b/examples/src/test/scala/com/wix/accord/examples/ScalaTest.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/examples/src/test/scala/com/wix/accord/examples/Specs2.scala
+++ b/examples/src/test/scala/com/wix/accord/examples/Specs2.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/java8/src/main/scala/com/wix/accord/java8/TemporalCombinators.scala
+++ b/java8/src/main/scala/com/wix/accord/java8/TemporalCombinators.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/java8/src/main/scala/com/wix/accord/java8/TemporalOps.scala
+++ b/java8/src/main/scala/com/wix/accord/java8/TemporalOps.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/java8/src/main/scala/com/wix/accord/java8/package.scala
+++ b/java8/src/main/scala/com/wix/accord/java8/package.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/java8/src/test/scala/com/wix/accord/java8/tests/TemporalCombinatorTests.scala
+++ b/java8/src/test/scala/com/wix/accord/java8/tests/TemporalCombinatorTests.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/java8/src/test/scala/com/wix/accord/java8/tests/TemporalOpsTests.scala
+++ b/java8/src/test/scala/com/wix/accord/java8/tests/TemporalOpsTests.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/joda/src/main/scala/com/wix/accord/joda/ReadableInstantCombinators.scala
+++ b/joda/src/main/scala/com/wix/accord/joda/ReadableInstantCombinators.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/joda/src/main/scala/com/wix/accord/joda/ReadableInstantOps.scala
+++ b/joda/src/main/scala/com/wix/accord/joda/ReadableInstantOps.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/joda/src/main/scala/com/wix/accord/joda/package.scala
+++ b/joda/src/main/scala/com/wix/accord/joda/package.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/joda/src/test/scala/com/wix/accord/joda/tests/ReadableInstantCombinatorTests.scala
+++ b/joda/src/test/scala/com/wix/accord/joda/tests/ReadableInstantCombinatorTests.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/joda/src/test/scala/com/wix/accord/joda/tests/ReadableInstantOpsTests.scala
+++ b/joda/src/test/scala/com/wix/accord/joda/tests/ReadableInstantOpsTests.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.0.4
+sbt.version=1.1.6
 

--- a/project/scalajs.sbt
+++ b/project/scalajs.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin( "org.scala-js" % "sbt-scalajs" % "0.6.21" )
+addSbtPlugin( "org.scala-js" % "sbt-scalajs" % "0.6.22" )

--- a/scalatest/src/main/scala/com/wix/accord/scalatest/CombinatorTestSpec.scala
+++ b/scalatest/src/main/scala/com/wix/accord/scalatest/CombinatorTestSpec.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/scalatest/src/main/scala/com/wix/accord/scalatest/ResultMatchers.scala
+++ b/scalatest/src/main/scala/com/wix/accord/scalatest/ResultMatchers.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/scalatest/src/test/scala/com/wix/accord/scalatest/ResultMatchersTest.scala
+++ b/scalatest/src/test/scala/com/wix/accord/scalatest/ResultMatchersTest.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/specs2/src/main/scala/com/wix/accord/specs2/ResultMatchers.scala
+++ b/specs2/src/main/scala/com/wix/accord/specs2/ResultMatchers.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/specs2/src/test/scala/com/wix/accord/specs2/ResultMatchersSpec.scala
+++ b/specs2/src/test/scala/com/wix/accord/specs2/ResultMatchersSpec.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/spring3/src/main/scala/com/wix/accord/spring/AccordEnabledLocalValidationFactory.scala
+++ b/spring3/src/main/scala/com/wix/accord/spring/AccordEnabledLocalValidationFactory.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/spring3/src/main/scala/com/wix/accord/spring/AccordValidatorAdapter.scala
+++ b/spring3/src/main/scala/com/wix/accord/spring/AccordValidatorAdapter.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/spring3/src/main/scala/com/wix/accord/spring/AccordValidatorResolver.scala
+++ b/spring3/src/main/scala/com/wix/accord/spring/AccordValidatorResolver.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/spring3/src/main/scala/com/wix/accord/spring/SpringAdapterBase.scala
+++ b/spring3/src/main/scala/com/wix/accord/spring/SpringAdapterBase.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/spring3/src/test/scala/com/wix/accord/spring/AccordEnabledLocalValidationFactoryTest.scala
+++ b/spring3/src/test/scala/com/wix/accord/spring/AccordEnabledLocalValidationFactoryTest.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/spring3/src/test/scala/com/wix/accord/spring/AccordValidatorAdapterTest.scala
+++ b/spring3/src/test/scala/com/wix/accord/spring/AccordValidatorAdapterTest.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/spring3/src/test/scala/com/wix/accord/spring/AccordValidatorResolverCacheTest.scala
+++ b/spring3/src/test/scala/com/wix/accord/spring/AccordValidatorResolverCacheTest.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/spring3/src/test/scala/com/wix/accord/spring/CompanionObjectAccordValidatorResolverTest.scala
+++ b/spring3/src/test/scala/com/wix/accord/spring/CompanionObjectAccordValidatorResolverTest.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2017 Wix.com
+  Copyright 2013-2019 Wix.com
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.


### PR DESCRIPTION
Binaries for Scala.js 0.6.21 on Scala 2.12.6 are gone from the central repo (not sure how that happens...), which is the primary trigger for this PR.

Other minor changes include:
* Support JDK 9+ builds
* Set up Travis to build on JDK 8 and 11 (as 10 is deprecated)
* Copyright notice updates
* Scala.js version badge on index