### PR TITLE
Add support for .map and .flatMap syntax in the context of .each DSL

### DIFF
--- a/core/src/main/scala/com/wix/accord/dsl/DslContext.scala
+++ b/core/src/main/scala/com/wix/accord/dsl/DslContext.scala
@@ -16,8 +16,10 @@
 
 package com.wix.accord.dsl
 
-import com.wix.accord.{Result, Validator}
 import com.wix.accord.ResultBuilders._
+import com.wix.accord.{Result, Validator}
+
+import scala.language.reflectiveCalls
 
 // TODO ScalaDocs
 
@@ -25,12 +27,12 @@ trait ContextTransformer[ Inner, Outer ] {
   protected def transform: Validator[ Inner ] => Validator[ Outer ]
 }
 
-class CollectionDslContext[ Inner, Outer ]( protected val transform: Validator[ Inner ] => Validator[ Outer ] )
-  extends ContextTransformer[ Inner, Outer ] {
+class CollectionDslContext[ Element, Coll ]( protected val transform: Validator[ Element ] => Validator[ Coll ] )
+  extends DslContext[ Element, Coll ] with ContextTransformer[ Element, Coll ] {
 
-  def apply( validator: Validator[ Int ] )( implicit ev: Inner => HasSize ): Validator[ Outer ] = {
-    val composed = new Validator[ Inner ] {
-      override def apply( v1: Inner ): Result =
+  def apply( validator: Validator[ Int ] )( implicit ev: Element => HasSize ): Validator[ Coll ] = {
+    val composed = new Validator[ Element ] {
+      override def apply( v1: Element ): Result =
         if ( v1 == null )
           Validator.nullFailure
         else
@@ -40,27 +42,83 @@ class CollectionDslContext[ Inner, Outer ]( protected val transform: Validator[ 
   }
 }
 
+case class CollectionContextTransformer[ Element, Coll ]( transformWith: IndexedDescriptions[ Coll ] =>
+                                                                         Validator[ Element ] =>
+                                                                         Validator[ Coll ] ) {
+
+  def apply( withIndices: IndexedDescriptions[ Coll ] ): Validator[ Element ] => Validator[ Coll ] =
+    transformWith( withIndices )
+
+  def compose[ A ]( g: Validator[ A ] => Validator[ Element ] ): CollectionContextTransformer[ A, Coll ] =
+    CollectionContextTransformer[ A, Coll ](
+      apply( _: IndexedDescriptions[ Coll ] ) compose g
+    )
+}
+
+class CollectionEachDslContext[ Element, Coll ]( withIndices: IndexedDescriptions[ Coll ],
+                                                 transformWith: CollectionContextTransformer[ Element, Coll ] )
+  extends CollectionDslContext[ Element, Coll ]( transformWith( withIndices ) ) {
+
+  /** Adapts the syntax for the collections. Enables validation rules such as `c.students.each.map(_.age) should be >= 18`.
+    * @param f The function to apply to each element of a collection before subsequent validation rules are applied.
+    * @tparam MappedElement The resulting element type of a collection after f is applied.
+    * @return Syntax, where the collection elements are of type [[MappedElement]],
+    *         resulting from applying function f to each element.
+    */
+  def map[ MappedElement ]( f: Element => MappedElement ) =
+    new CollectionEachDslContext[ MappedElement, Coll ](
+      withIndices,
+      transformWith.compose { v: Validator[ MappedElement ] =>
+        v compose f
+      }
+    )
+
+  /** Adapts the syntax for the collections. Enables validation rules such as
+    *   `c.students.each.flatMap(_.guardians).map(_.age) should be >= 30`.
+    * @param f The function to apply to each element of a collection, producing a new collection after each application.
+    * @tparam MappedElement The resulting element type of a collection after f is applied.
+    * @return Syntax, where the collection elements are of type [[MappedElement]],
+    *         resulting from applying function f to each element and concatenating the results.
+    */
+  def flatMap[ MappedElement ]( f: Element => Iterable[ MappedElement ] )
+                              ( implicit withIndices: IndexedDescriptions[ Coll ] ) =
+    new CollectionEachDslContext[ MappedElement, Coll ](
+      IndexedDescriptions( includeIndices = false ),
+      transformWith.compose { validator: Validator[ MappedElement ] =>
+        val broadcast =
+          Aggregates.all[ Iterable[ MappedElement ], MappedElement ]( withIndices.includeIndexInformation ) _
+        broadcast(validator) compose f
+      }
+    )
+}
+
 trait IndexedDescriptions[ T ] {
   def includeIndexInformation: Boolean
 }
 
 trait FallbackIndexDescriptions {
-  implicit def disableIndexDescriptionsByDefault[ T ] = new IndexedDescriptions[ T ] {
-    def includeIndexInformation: Boolean = false
-  }
+  implicit def disableIndexDescriptionsByDefault[ T ]: IndexedDescriptions[ T ] =
+    IndexedDescriptions( includeIndices = false )
 }
 
 object IndexedDescriptions extends FallbackIndexDescriptions {
   implicit def enableIndexingForSequences[ T ]( implicit ev: T => Seq[_] ): IndexedDescriptions[ T ] =
-    new IndexedDescriptions [ T ] { def includeIndexInformation: Boolean = true }
+    IndexedDescriptions( includeIndices = true )
+
+  def apply[ T ]( includeIndices: Boolean ): IndexedDescriptions[ T ] =
+    new IndexedDescriptions[ T ] {
+      override def includeIndexInformation: Boolean = includeIndices
+    }
 }
 
 trait DslContext[ Inner, Outer ] {
   self: ContextTransformer[ Inner, Outer ] =>
 
-  def is    ( validator: Validator[ Inner ] ): Validator[ Outer ] = transform apply validator
-  def should( validator: Validator[ Inner ] ): Validator[ Outer ] = transform apply validator
-  def must  ( validator: Validator[ Inner ] ): Validator[ Outer ] = transform apply validator
+  private def apply( validator: Validator[ Inner ] ): Validator[ Outer ] = transform apply validator
+
+  def is    ( validator: Validator[ Inner ] ): Validator[ Outer ] = apply( validator )
+  def should( validator: Validator[ Inner ] ): Validator[ Outer ] = apply( validator )
+  def must  ( validator: Validator[ Inner ] ): Validator[ Outer ] = apply( validator )
 
   /** Provides extended syntax for collections; enables validation rules such as `c.students.each is valid`.
     *
@@ -68,13 +126,15 @@ trait DslContext[ Inner, Outer ] {
     * @tparam Element The element type m of the specified collection.
     * @return Additional syntax (see implementation).
     */
-  def each[ Element ]( implicit ev: Inner => Traversable[ Element ], withIndices: IndexedDescriptions[ Inner ] ) =
-    new DslContext[ Element, Outer ] with ContextTransformer[ Element, Outer ] {
-      protected override def transform =
+  def each[ Element ]( implicit ev: Inner => Iterable[ Element ], withIndices: IndexedDescriptions[ Inner ] ) =
+    new CollectionEachDslContext[ Element, Outer ](
+      IndexedDescriptions[ Outer ]( withIndices.includeIndexInformation ),
+      CollectionContextTransformer( withIndices =>
         self.transform compose Aggregates.all[ Inner, Element ]( withIndices.includeIndexInformation )
-    }
+      )
+    )
 
-  private val collContext = new CollectionDslContext( transform )
+  private def collContext = new CollectionDslContext[ Inner, Outer ]( transform )
   def has: CollectionDslContext[ Inner, Outer ] = collContext
   def have: CollectionDslContext[ Inner, Outer ] = collContext
 }

--- a/core/src/main/scala/com/wix/accord/dsl/DslContext.scala
+++ b/core/src/main/scala/com/wix/accord/dsl/DslContext.scala
@@ -80,13 +80,13 @@ class CollectionEachDslContext[ Element, Coll ]( withIndices: IndexedDescription
     * @return Syntax, where the collection elements are of type [[MappedElement]],
     *         resulting from applying function f to each element and concatenating the results.
     */
-  def flatMap[ MappedElement ]( f: Element => Iterable[ MappedElement ] )
+  def flatMap[ MappedElement ]( f: Element => Traversable[ MappedElement ] )
                               ( implicit withIndices: IndexedDescriptions[ Coll ] ) =
     new CollectionEachDslContext[ MappedElement, Coll ](
       IndexedDescriptions( includeIndices = false ),
       transformWith.compose { validator: Validator[ MappedElement ] =>
         val broadcast =
-          Aggregates.all[ Iterable[ MappedElement ], MappedElement ]( withIndices.includeIndexInformation ) _
+          Aggregates.all[ Traversable[ MappedElement ], MappedElement ]( withIndices.includeIndexInformation ) _
         broadcast(validator) compose f
       }
     )
@@ -126,7 +126,7 @@ trait DslContext[ Inner, Outer ] {
     * @tparam Element The element type m of the specified collection.
     * @return Additional syntax (see implementation).
     */
-  def each[ Element ]( implicit ev: Inner => Iterable[ Element ], withIndices: IndexedDescriptions[ Inner ] ) =
+  def each[ Element ]( implicit ev: Inner => Traversable[ Element ], withIndices: IndexedDescriptions[ Inner ] ) =
     new CollectionEachDslContext[ Element, Outer ](
       IndexedDescriptions[ Outer ]( withIndices.includeIndexInformation ),
       CollectionContextTransformer( withIndices =>

--- a/core/src/test/scala/com/wix/accord/tests/dsl/CollectionOpsTests.scala
+++ b/core/src/test/scala/com/wix/accord/tests/dsl/CollectionOpsTests.scala
@@ -110,7 +110,7 @@ class CollectionOpsTests extends WordSpec with Matchers with ResultMatchers with
     }
   }
 
-  "Calling \".each\" on an Iterable" should {
+  "Calling \".each\" on a Traversable" should {
     "apply subsequent validation rules to all elements" in {
       val coll = Seq.fill( 5 )( ArbitraryType.apply )
       val visited = mutable.ListBuffer.empty[ ArbitraryType ]


### PR DESCRIPTION
Makes the following syntax instances valid:
```
      classroom.students.each map { _.age } should be >= 18
      classroom.students.each map { _.age } map { _.toString } is notEmpty

      classroom.students.each flatMap { _.guardians } is valid
      classroom.students.each flatMap { _.guardians } map { _.age } should be >= 30
      classroom.students.each flatMap { _.guardians.headOption } map { _.age } should be >= 0
      
      classroom.students.each flatMap { _.guardians } has size.between(0, 2)
```

I'm not entirely sure supporting `flatMap` or any other non-structure-preserving operation is the right way to go. 
Suppose you have `val coll = Seq(0, 2)` and a function `val extend = (i: Int) => Seq(i, i + 1)`. `coll flatMap extend` would produce `Seq(0, 1, 2, 3)`. Now, if element `1: Int` is invalid, `coll.each flatMap extend is valid` would refer to [at index 1] - **after** collection transformation.
This works, but may overcomplicate validators.



Also, replaced Traversable[\_] with Iterable[\_] because of 2.13 collections rework.