### PR TITLE
Update scalatest to 3.1.0

### DIFF
--- a/api/src/test/scala/com/wix/accord/DebugRenderingSpec.scala
+++ b/api/src/test/scala/com/wix/accord/DebugRenderingSpec.scala
@@ -17,12 +17,13 @@
 package com.wix.accord
 
 import com.wix.accord.Descriptions.{Generic, Path}
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 /**
   * Created by grenville on 9/6/16.
   */
-class DebugRenderingSpec extends WordSpec with Matchers {
+class DebugRenderingSpec extends AnyWordSpec with Matchers {
 
   object RuleViolations {
     val full = RuleViolation( "string", "must start with \"test\"", Path( Generic( "full" ) ) )
@@ -32,7 +33,7 @@ class DebugRenderingSpec extends WordSpec with Matchers {
   }
 
   object GroupViolations {
-    val children = Set[ Violation ]( RuleViolations.full, RuleViolations.emptySeq )
+    val children: Set[Violation] = Set[ Violation ]( RuleViolations.full, RuleViolations.emptySeq )
 
     val full =
       GroupViolation( "some value", "doesn't meet any of the requirements", children, Path( Generic( "full" ) ) )

--- a/api/src/test/scala/com/wix/accord/DescriptionRenderingSpec.scala
+++ b/api/src/test/scala/com/wix/accord/DescriptionRenderingSpec.scala
@@ -16,9 +16,10 @@
 
 package com.wix.accord
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class DescriptionRenderingSpec extends FlatSpec with Matchers {
+class DescriptionRenderingSpec extends AnyFlatSpec with Matchers {
   import Descriptions._
 
   "Rendering a path" should "result in a Scala-style indirection chain with dot separation" in {

--- a/build.sbt
+++ b/build.sbt
@@ -105,7 +105,7 @@ lazy val api =
         "Accord is a validation library written in and for Scala. Its chief aim is to provide a composable, " +
         "dead-simple and self-contained story for defining validation rules and executing them on object " +
         "instances. Feedback, bug reports and improvements are welcome!",
-      libraryDependencies += "org.scalatest" %%% "scalatest" % "3.0.8",
+      libraryDependencies += "org.scalatest" %%% "scalatest" % "3.1.0",
       noFatalWarningsOn( configuration = Test )
     ) ++ baseSettings :_* )
   .jsSettings( limitPackageSize( 160 ) )
@@ -119,7 +119,7 @@ lazy val scalatest =
     .settings( baseSettings ++ Seq(
       name := "accord-scalatest",
       description := "ScalaTest matchers for the Accord validation library",
-      libraryDependencies += "org.scalatest" %%% "scalatest" % "3.0.8",
+      libraryDependencies += "org.scalatest" %%% "scalatest" % "3.1.0",
       noFatalWarningsOn( configuration = Test )
     ) :_* )
   .jsSettings( limitPackageSize( 110 ) )
@@ -154,7 +154,7 @@ lazy val core =
         "Accord is a validation library written in and for Scala. Its chief aim is to provide a composable, " +
         "dead-simple and self-contained story for defining validation rules and executing them on object " +
         "instances. Feedback, bug reports and improvements are welcome!",
-      
+
       noFatalWarningsOn( configuration = Test ),  // Avoid failed test compilation due to deprecations // TODO remove
 
       // Scala 2.13 deprecates a number of older collection traits like Traversable and the family of Gen*

--- a/core/src/test/scala/com/wix/accord/BaseValidatorTests.scala
+++ b/core/src/test/scala/com/wix/accord/BaseValidatorTests.scala
@@ -16,11 +16,11 @@
 
 package com.wix.accord
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.LoneElement._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec    // Compilation fails when mixing this in, no idea why.
 
-import org.scalatest.LoneElement._    // Compilation fails when mixing this in, no idea why.
-
-class BaseValidatorTests extends WordSpec with Matchers with ViolationBuilder {
+class BaseValidatorTests extends AnyWordSpec with Matchers with ViolationBuilder {
   "BaseValidator.report" should {
 
     val validator = new NullSafeValidator[ String ]( _ startsWith "ok", _ -> "no good" )

--- a/core/src/test/scala/com/wix/accord/tests/dsl/BooleanOpsTests.scala
+++ b/core/src/test/scala/com/wix/accord/tests/dsl/BooleanOpsTests.scala
@@ -16,12 +16,12 @@
 
 package com.wix.accord.tests.dsl
 
-import com.wix.accord.scalatest.ResultMatchers
-import org.scalatest.{Matchers, WordSpec}
-
 import com.wix.accord._
+import com.wix.accord.scalatest.ResultMatchers
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class BooleanOpsTests extends WordSpec with Matchers with ResultMatchers {
+class BooleanOpsTests extends AnyWordSpec with Matchers with ResultMatchers {
   import BooleanOpsTests._
 
   "true" should {

--- a/core/src/test/scala/com/wix/accord/tests/dsl/CollectionOpsTests.scala
+++ b/core/src/test/scala/com/wix/accord/tests/dsl/CollectionOpsTests.scala
@@ -19,8 +19,9 @@ package com.wix.accord.tests.dsl
 import com.wix.accord.Descriptions.{Generic, Indexed, Path}
 import com.wix.accord._
 import com.wix.accord.scalatest.ResultMatchers
-import org.scalatest.{Inside, Matchers, WordSpec}
-
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.{Inside, WordSpec}
 
 import scala.collection.mutable
 
@@ -54,7 +55,7 @@ object CollectionOpsTests {
   def visitEach[ T ]( set: Set[ T ] )( visited: T => Result ): Result = ( set.each is visited )( set )
 }
 
-class CollectionOpsTests extends WordSpec with Matchers with ResultMatchers with Inside {
+class CollectionOpsTests extends AnyWordSpec with Matchers with ResultMatchers with Inside {
   import CollectionOpsTests._
   import combinators.{Empty, NotEmpty, Distinct,In}
 

--- a/core/src/test/scala/com/wix/accord/tests/dsl/GenericOpsTests.scala
+++ b/core/src/test/scala/com/wix/accord/tests/dsl/GenericOpsTests.scala
@@ -13,14 +13,14 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-
 package com.wix.accord.tests.dsl
 
-import com.wix.accord.scalatest.ResultMatchers
-import org.scalatest.{Matchers, WordSpec}
 import com.wix.accord.combinators.{AnInstanceOf, EqualTo, IsNotNull, IsNull, NotAnInstanceOf, NotEqualTo}
+import com.wix.accord.scalatest.ResultMatchers
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class GenericOpsTests extends WordSpec with Matchers with ResultMatchers {
+class GenericOpsTests extends AnyWordSpec with Matchers with ResultMatchers {
   import GenericOpsTests._
   
   "The expression \"is aNull\"" should {

--- a/core/src/test/scala/com/wix/accord/tests/dsl/OptionOpsTests.scala
+++ b/core/src/test/scala/com/wix/accord/tests/dsl/OptionOpsTests.scala
@@ -17,11 +17,12 @@
 package com.wix.accord.tests.dsl
 
 import com.wix.accord.Descriptions.{Generic, Path}
-import com.wix.accord.scalatest.ResultMatchers
-import org.scalatest.{Matchers, WordSpec}
 import com.wix.accord.Validator
+import com.wix.accord.scalatest.ResultMatchers
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class OptionOpsTests extends WordSpec with Matchers with ResultMatchers {
+class OptionOpsTests extends AnyWordSpec with Matchers with ResultMatchers {
   import OptionOpsTests._
 
   // Quick and dirty helper to make the tests a little more terse

--- a/core/src/test/scala/com/wix/accord/tests/dsl/OrderingOpsTests.scala
+++ b/core/src/test/scala/com/wix/accord/tests/dsl/OrderingOpsTests.scala
@@ -17,7 +17,8 @@
 package com.wix.accord.tests.dsl
 
 import com.wix.accord.dsl.OrderingOps
-import org.scalatest.{FlatSpec, Inside, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{FlatSpec, Inside, fixture}
 
 import scala.collection.immutable.NumericRange
 

--- a/core/src/test/scala/com/wix/accord/tests/dsl/StringOpsTests.scala
+++ b/core/src/test/scala/com/wix/accord/tests/dsl/StringOpsTests.scala
@@ -16,11 +16,12 @@
 
 package com.wix.accord.tests.dsl
 
-import com.wix.accord.scalatest.ResultMatchers
-import org.scalatest.{Matchers, WordSpec}
 import com.wix.accord.Validator
+import com.wix.accord.scalatest.ResultMatchers
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class StringOpsTests extends WordSpec with Matchers with ResultMatchers {
+class StringOpsTests extends AnyWordSpec with Matchers with ResultMatchers {
   import StringOpsTests._
 
   // Quick and dirty helper to make the tests a little more terse

--- a/core/src/test/scala/com/wix/accord/tests/transform/ExpressionDescriberTests.scala
+++ b/core/src/test/scala/com/wix/accord/tests/transform/ExpressionDescriberTests.scala
@@ -17,10 +17,11 @@
 package com.wix.accord.tests.transform
 
 import com.wix.accord.Descriptions._
-import org.scalatest.{Matchers, WordSpec}
 import com.wix.accord.transform.ExpressionDescriber
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ExpressionDescriberTests extends WordSpec with Matchers {
+class ExpressionDescriberTests extends AnyWordSpec with Matchers {
   import com.wix.accord.dsl.Descriptor
 
   case class Nested( field: String )

--- a/core/src/test/scala/com/wix/accord/tests/transform/ValidationTransformTests.scala
+++ b/core/src/test/scala/com/wix/accord/tests/transform/ValidationTransformTests.scala
@@ -17,11 +17,12 @@
 package com.wix.accord.tests.transform
 
 import com.wix.accord.Descriptions._
-import org.scalatest.{Matchers, WordSpec}
 import com.wix.accord._
 import com.wix.accord.scalatest.ResultMatchers
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ValidationTransformTests extends WordSpec with Matchers with ResultMatchers {
+class ValidationTransformTests extends AnyWordSpec with Matchers with ResultMatchers {
   import ValidationTransformTests._
 
 

--- a/examples/src/test/scala/com/wix/accord/examples/ScalaTest.scala
+++ b/examples/src/test/scala/com/wix/accord/examples/ScalaTest.scala
@@ -17,10 +17,12 @@
 package com.wix.accord.examples
 
 import com.wix.accord.scalatest.ResultMatchers
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
 import scala.util.Random
 
-class ScalaTest extends WordSpec with Matchers with ResultMatchers {
+class ScalaTest extends AnyWordSpec with Matchers with ResultMatchers {
   import com.wix.accord._
 
   val validAdult = Adult( name = "Grace", surname = "Hopper", age = 85, contactInfo = "Arlington National Cemetery" )

--- a/java8/src/test/scala/com/wix/accord/java8/tests/TemporalOpsTests.scala
+++ b/java8/src/test/scala/com/wix/accord/java8/tests/TemporalOpsTests.scala
@@ -16,17 +16,16 @@
 
 package com.wix.accord.java8.tests
 
+import java.time.ZoneOffset
 
-import java.time.temporal.ChronoUnit
-import java.time.{LocalDateTime, ZoneOffset}
 import com.wix.accord.scalatest.ResultMatchers
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-import org.scalatest.{Matchers, WordSpec}
+class TemporalOpsTests extends AnyWordSpec with Matchers with ResultMatchers {
 
-class TemporalOpsTests extends WordSpec with Matchers with ResultMatchers {
-
-  import com.wix.accord.java8.{Before, After, Within}
   import TemporalOpsTests._
+  import com.wix.accord.java8.{After, Before, Within}
 
   "The expression \"is before\"" should {
     "produce a Before combinator" in {
@@ -70,8 +69,8 @@ class TemporalOpsTests extends WordSpec with Matchers with ResultMatchers {
 }
 
 object TemporalOpsTests {
-  import java.time.{LocalDateTime, Duration}
   import java.time.temporal.{ChronoUnit, Temporal}
+  import java.time.{Duration, LocalDateTime}
 
   import com.wix.accord.dsl._
   import com.wix.accord.java8._

--- a/joda/src/test/scala/com/wix/accord/joda/tests/ReadableInstantOpsTests.scala
+++ b/joda/src/test/scala/com/wix/accord/joda/tests/ReadableInstantOpsTests.scala
@@ -18,9 +18,10 @@ package com.wix.accord.joda.tests
 
 import com.wix.accord.scalatest.ResultMatchers
 import org.joda.time._
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ReadableInstantOpsTests extends WordSpec with Matchers with ResultMatchers {
+class ReadableInstantOpsTests extends AnyWordSpec with Matchers with ResultMatchers {
 
   import com.wix.accord.joda.{Before, After, Within}
   import ReadableInstantOpsTests._

--- a/scalatest/src/main/scala/com/wix/accord/scalatest/CombinatorTestSpec.scala
+++ b/scalatest/src/main/scala/com/wix/accord/scalatest/CombinatorTestSpec.scala
@@ -16,7 +16,8 @@
 
 package com.wix.accord.scalatest
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 
 /**
@@ -24,7 +25,7 @@ import org.scalatest.{Matchers, WordSpec}
   * is test-first via this specification:
   *
   * {{{
-  * class MyCombinatorSpec extends WordSpec with ResultMatchers with Matchers {
+  * class MyCombinatorSpec extends AnyWordSpec with ResultMatchers with Matchers {
   *
   *   def isMonotonous[ T ]: Validator[ Iterable[ T ] ] = ???
   *
@@ -42,7 +43,7 @@ import org.scalatest.{Matchers, WordSpec}
   * }}}
   *
   */
-trait CombinatorTestSpec extends WordSpec with Matchers with ResultMatchers {
+trait CombinatorTestSpec extends AnyWordSpec with Matchers with ResultMatchers {
   import scala.language.implicitConversions
 
   implicit def elevateStringToRuleViolationMatcher( s: String ): RuleViolationMatcher =

--- a/scalatest/src/test/scala/com/wix/accord/scalatest/ResultMatchersTest.scala
+++ b/scalatest/src/test/scala/com/wix/accord/scalatest/ResultMatchersTest.scala
@@ -17,13 +17,14 @@
 package com.wix.accord.scalatest
 
 import com.wix.accord.Descriptions.{Generic, Path}
-import org.scalatest.{Matchers, WordSpec}
 import com.wix.accord._
 import com.wix.accord.GroupViolation
 import com.wix.accord.RuleViolation
 import com.wix.accord.Failure
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ResultMatchersTest extends WordSpec with Matchers with ResultMatchers {
+class ResultMatchersTest extends AnyWordSpec with Matchers with ResultMatchers {
 
   "RuleViolationMatcher" should {
 

--- a/spring3/src/test/scala/com/wix/accord/spring/AccordEnabledLocalValidationFactoryTest.scala
+++ b/spring3/src/test/scala/com/wix/accord/spring/AccordEnabledLocalValidationFactoryTest.scala
@@ -16,16 +16,15 @@
 
 package com.wix.accord.spring
 
-import org.scalatest.{Matchers, WordSpec}
-
-import org.springframework.test.context.{TestContextManager, ContextConfiguration}
+import org.springframework.test.context.{ContextConfiguration, TestContextManager}
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.validation.{BeanPropertyBindingResult, Validator}
-
 import AccordEnabledLocalValidationFactoryTest._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 @ContextConfiguration( classes = Array( classOf[ SpringValidationConfiguration ] ) )
-class AccordEnabledLocalValidationFactoryTest extends WordSpec with Matchers {
+class AccordEnabledLocalValidationFactoryTest extends AnyWordSpec with Matchers {
 
   new TestContextManager( this.getClass ).prepareTestInstance( this )
 

--- a/spring3/src/test/scala/com/wix/accord/spring/AccordValidatorResolverCacheTest.scala
+++ b/spring3/src/test/scala/com/wix/accord/spring/AccordValidatorResolverCacheTest.scala
@@ -18,12 +18,12 @@ package com.wix.accord.spring
 
 import com.wix.accord.Validator
 import com.wix.accord.dsl._
-import org.scalatest.{Matchers, WordSpec}
-
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 import scala.reflect.ClassTag
 
-class AccordValidatorResolverCacheTest extends WordSpec with Matchers {
+class AccordValidatorResolverCacheTest extends AnyWordSpec with Matchers {
 
   import AccordValidatorResolverCacheTest._
 

--- a/spring3/src/test/scala/com/wix/accord/spring/CompanionObjectAccordValidatorResolverTest.scala
+++ b/spring3/src/test/scala/com/wix/accord/spring/CompanionObjectAccordValidatorResolverTest.scala
@@ -17,11 +17,12 @@
 package com.wix.accord.spring
 
 import com.wix.accord._
-import org.scalatest.{Matchers, WordSpec}
 import com.wix.accord.scalatest.ResultMatchers
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 trait CompanionObjectValidatorResolverBehaviors extends Matchers with ResultMatchers {
-  this: WordSpec =>
+  this: AnyWordSpec =>
 
   import CompanionObjectAccordValidatorResolverTest._
 
@@ -51,7 +52,7 @@ trait CompanionObjectValidatorResolverBehaviors extends Matchers with ResultMatc
   }
 }
 
-class CompanionObjectAccordValidatorResolverTest extends WordSpec with CompanionObjectValidatorResolverBehaviors {
+class CompanionObjectAccordValidatorResolverTest extends AnyWordSpec with CompanionObjectValidatorResolverBehaviors {
 
   "CompanionObjectAccordValidatorResolver" should {
     behave like companionObjectValidatorResolver( new CompanionObjectAccordValidatorResolver )

--- a/spring3/src/test/scala_2.13-/com/wix/accord/spring/AccordValidatorAdapterTest.scala
+++ b/spring3/src/test/scala_2.13-/com/wix/accord/spring/AccordValidatorAdapterTest.scala
@@ -17,14 +17,14 @@
 package com.wix.accord.spring
 
 import com.wix.accord.dsl
-import org.scalatest.{Matchers, WordSpec}
-
+import com.wix.accord.spring.AccordValidatorAdapterTest._
+import org.scalatest.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import org.springframework.validation.{BeanPropertyBindingResult, Errors}
+
 import scala.collection.JavaConverters._
 
-import AccordValidatorAdapterTest._
-
-class AccordValidatorAdapterTest extends WordSpec with Matchers {
+class AccordValidatorAdapterTest extends AnyWordSpec with Matchers {
 
   "The validation adapter" should {
     def adapter = new AccordValidatorAdapter( testClassValidator )


### PR DESCRIPTION
Otherwise this library leads to `ClassNotFound` errors due to the moved `Matchers` class if the actual project has updated to scalatest `3.1.0`